### PR TITLE
Add coadd functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ This repo is a rewrite of https://github.com/desihub/inspector, which itself is 
 ## Currently missing (but present in the original inspector)
 
 * Imaging survey thumbnails and links.
-* Buttons for navigating previous/next target
 * Buttons for saving visual inspection results before moving to next target.
 
 ## What it doesn't do (yet)

--- a/plotframes.py
+++ b/plotframes.py
@@ -28,6 +28,119 @@ from desitarget.targetmask import desi_mask
 import desispec.spectra
 import desispec.frame
 
+def _coadd(wave, flux, ivar, rdat):
+    '''
+    Return weighted coadd of spectra
+
+    Parameters
+    ----------
+    wave : 1D[nwave] array of wavelengths
+    flux : 2D[nspec, nwave] array of flux densities
+    ivar : 2D[nspec, nwave] array of inverse variances of `flux`
+    rdat : 3D[nspec, ndiag, nwave] sparse diagonals of resolution matrix
+
+    Returns
+    -------
+        coadded spectrum (wave, outflux, outivar, outrdat)
+    '''
+    nspec, nwave = flux.shape
+    unweightedflux = np.zeros(nwave, dtype=flux.dtype)
+    weightedflux = np.zeros(nwave, dtype=flux.dtype)
+    weights = np.zeros(nwave, dtype=flux.dtype)
+    outrdat = np.zeros(rdat[0].shape, dtype=rdat.dtype)
+    for i in range(nspec):
+        unweightedflux += flux[i]
+        weightedflux += flux[i] * ivar[i]
+        weights += ivar[i]
+        outrdat += rdat[i] * ivar[i]
+
+    isbad = (weights == 0)
+    outflux = weightedflux / (weights + isbad)
+    outflux[isbad] = unweightedflux[isbad] / nspec
+
+    outrdat /= (weights + isbad)
+    outivar = weights
+
+    return wave, outflux, outivar, outrdat
+
+def _coadd_targets(spectra, targetids=None):
+    '''
+    Coadds individual exposures of the same targets; returns new Spectra object
+
+    Parameters
+    ----------
+    spectra : :class:`desispec.spectra.Spectra`
+    targetids : (optional) array-like subset of target IDs to keep
+
+    Returns
+    -------
+    coadded_spectra : :class:`desispec.spectra.Spectra` where individual
+        spectra of each target have been combined into a single spectrum
+        per camera.
+
+    Note: coadds per camera but not across cameras.
+    '''
+    if targetids is None:
+        targetids = spectra.target_ids()
+
+    #- Create output arrays to fill
+    ntargets = spectra.num_targets()
+    wave = dict()
+    flux = dict()
+    ivar = dict()
+    rdat = dict()
+    if spectra.mask is None:
+        mask = None
+    else:
+        mask = dict()
+    for channel in spectra.bands:
+        wave[channel] = spectra.wave[channel].copy()
+        nwave = len(wave[channel])
+        flux[channel] = np.zeros((ntargets, nwave))
+        ivar[channel] = np.zeros((ntargets, nwave))
+        ndiag = spectra.resolution_data[channel].shape[1]
+        rdat[channel] = np.zeros((ntargets, ndiag, nwave))
+        if mask is not None:
+            mask[channel] = np.zeros((ntargets, nwave), dtype=spectra.mask[channel].dtype)
+
+    #- Loop over targets, coadding all spectra for each target
+    fibermap = Table(dtype=spectra.fibermap.dtype)
+    for i, targetid in enumerate(targetids):
+        ii = np.where(spectra.fibermap['TARGETID'] == targetid)[0]
+        fibermap.add_row(spectra.fibermap[ii[0]])
+        for channel in spectra.bands:
+            if len(ii) > 1:
+                outwave, outflux, outivar, outrdat = _coadd(
+                    spectra.wave[channel],
+                    spectra.flux[channel][ii],
+                    spectra.ivar[channel][ii],
+                    spectra.resolution_data[channel][ii]
+                    )
+                if mask is not None:
+                    outmask = spectra.mask[channel][ii[0]]
+                    for j in range(1, len(ii)):
+                        outmask |= spectra.mask[channel][ii[j]]
+            else:
+                outwave, outflux, outivar, outrdat = (
+                    spectra.wave[channel],
+                    spectra.flux[channel][ii[0]],
+                    spectra.ivar[channel][ii[0]],
+                    spectra.resolution_data[channel][ii[0]]
+                    )
+                if mask is not None:
+                    outmask = spectra.mask[channel][ii[0]]
+
+            flux[channel][i] = outflux
+            ivar[channel][i] = outivar
+            rdat[channel][i] = outrdat
+            if mask is not None:
+                mask[channel][i] = outmask
+
+    return desispec.spectra.Spectra(spectra.bands, wave, flux, ivar,
+            mask=mask, resolution_data=rdat, fibermap=fibermap,
+            meta=spectra.meta)
+
+
 def frames2spectra(frames):
     '''Convert input list of Frames into Spectra object
 
@@ -45,7 +158,7 @@ def frames2spectra(frames):
         flux[band] = fr.flux
         ivar[band] = fr.ivar
         mask[band] = fr.mask
-    
+
     spectra = desispec.spectra.Spectra(
         bands, wave, flux, ivar, mask, fibermap=fr.fibermap, meta=fr.meta
     )
@@ -596,7 +709,7 @@ def plotspectra(spectra, zcatalog=None, model=None, notebook=False, title=None):
             ),
         widgetbox(lines_button_group),
         ))
- 
+
     #--- DEBUG ---
     # import IPython
     # IPython.embed()
@@ -765,4 +878,3 @@ if __name__ == '__main__':
     mwave, mflux = create_model(spectra, zbest)
 
     plotspectra(spectra, zcatalog=zbest, model=(mwave, mflux), title=os.path.basename(specfile))
-

--- a/plotframes.py
+++ b/plotframes.py
@@ -873,7 +873,8 @@ if __name__ == '__main__':
 
     specfile = 'data/spectra-64-5261.fits'
     zbfile = specfile.replace('spectra-64-', 'zbest-64-')
-    spectra = desispec.io.read_spectra(specfile)
+    individual_spectra = desispec.io.read_spectra(specfile)
+    spectra = _coadd_targets(individual_spectra)
     zbest = Table.read(zbfile, 'ZBEST')
     mwave, mflux = create_model(spectra, zbest)
 


### PR DESCRIPTION
This PR fixes #2 by copying the simple coadd code from Inspector.  In addition, I made some assumptions about how to handle masks: the mask of the coadd is the bitwise OR of the individual masks.  There is code in prospect that implicitly assumes a mask that is not `None`.  For example,
```python
bad = (spectra.ivar[band] == 0.0) | (spectra.mask[band] != 0)
```